### PR TITLE
Fix rectangle rounding and scale

### DIFF
--- a/include/raylib-nuklear.h
+++ b/include/raylib-nuklear.h
@@ -126,13 +126,6 @@ extern "C" {
 #define RAYLIB_NUKLEAR_DEFAULT_ARC_SEGMENTS 20
 #endif  // RAYLIB_NUKLEAR_DEFAULT_ARC_SEGMENTS
 
-#ifndef RAYLIB_NUKLEAR_ROUNDING_SCALE
-/**
- * The default scaling to apply for rounded borders.
- */
-#define RAYLIB_NUKLEAR_ROUNDING_SCALE 4.0f
-#endif
-
 /**
  * The user data that's leverages internally through Nuklear.
  */
@@ -402,8 +395,17 @@ DrawNuklear(struct nk_context * ctx)
                 const struct nk_command_rect *r = (const struct nk_command_rect *)cmd;
                 Color color = ColorFromNuklear(r->color);
                 Rectangle rect = {(float)r->x * scale, (float)r->y * scale, (float)r->w * scale, (float)r->h * scale};
-                float roundness = (float)r->rounding * RAYLIB_NUKLEAR_ROUNDING_SCALE / (rect.width + rect.height);
+                float roundness = (rect.width > rect.height) ?
+                        ((2 * r->rounding * scale)/rect.height) : ((2 * r->rounding * scale)/rect.width);
+                roundness = NK_CLAMP(0.0, roundness, 1.0);
                 if (roundness > 0.0f) {
+                    // DrawRectangleRoundedLines doesn't work in the same way as DrawRectangleLinesEx and it draws
+                    // the outline outside the region defined by the rectangle. To compensate for that, shrink
+                    // the rectangle by the thickness plus 1 (due to inconsistencies from DrawRectangleRoundedLines):
+                    rect.x += ((float) r->line_thickness) * scale + 1.0;
+                    rect.y += ((float) r->line_thickness) * scale + 1.0;
+                    rect.width = NK_MAX(rect.width - (2 * ((float) r->line_thickness) * scale + 1.0), 0.0);
+                    rect.height = NK_MAX(rect.height - (2 * ((float) r->line_thickness) * scale + 1.0), 0.0);
                     DrawRectangleRoundedLines(rect, roundness, RAYLIB_NUKLEAR_DEFAULT_ARC_SEGMENTS, (float)r->line_thickness * scale, color);
                 }
                 else {
@@ -415,7 +417,9 @@ DrawNuklear(struct nk_context * ctx)
                 const struct nk_command_rect_filled *r = (const struct nk_command_rect_filled *)cmd;
                 Color color = ColorFromNuklear(r->color);
                 Rectangle rect = {(float)r->x * scale, (float)r->y * scale, (float)r->w * scale, (float)r->h * scale};
-                float roundness = (float)r->rounding * RAYLIB_NUKLEAR_ROUNDING_SCALE / (rect.width + rect.height);
+                float roundness = (rect.width > rect.height) ?
+                        ((2 * r->rounding * scale)/rect.height) : ((2 * r->rounding * scale)/rect.width);
+                roundness = NK_CLAMP(0.0, roundness, 1.0);
                 if (roundness > 0.0f) {
                     DrawRectangleRounded(rect, roundness, RAYLIB_NUKLEAR_DEFAULT_ARC_SEGMENTS, color);
                 }


### PR DESCRIPTION
There are two problems related to how the library draws rectangles:

The first one is related to DrawRectangleRoundedLines(), which is different from all the other RayLib DrawRectangle*() functions because it draws the outline outside of the region defined by the Rectangle argument. To fix that, shrink the rectangle by the thickness plus one, to accommodate some imprecision from RayLib.

The second issue is related to the roundness value that needs to be calculated by the smallest dimension between width and height and clamped between 0 and 1. With that, RAYLIB_NUKLEAR_ROUNDING_SCALE can be dropped. In issue #28, you can see that the roundness of "Compression" widget is also wrong, that is solved by this fix.

Closes #28 