### PR TITLE
Fix nk_edit_string cursor

### DIFF
--- a/include/raylib-nuklear.h
+++ b/include/raylib-nuklear.h
@@ -147,7 +147,9 @@ nk_raylib_font_get_text_width(nk_handle handle, float height, const char *text, 
         // Grab the text with the cropped length so that it only measures the desired string length.
         const char* subtext = TextSubtext(text, 0, len);
 
-        return (float)MeasureText(subtext, (int)height);
+        // Raylib only counts the spacing between characters, but Nuklear expects one spacing to be
+        // counter for every character in the string:
+        return (float)MeasureText(subtext, (int)height) + height / 10.0f;
     }
 
     return 0;
@@ -166,7 +168,9 @@ nk_raylib_font_get_text_width_user_font(nk_handle handle, float height, const ch
         const char* subtext = TextSubtext(text, 0, len);
 
         // Spacing is determined by the font size divided by 10.
-        return MeasureTextEx(*(Font*)handle.ptr, subtext, height, height / 10.0f).x;
+        // Raylib only counts the spacing between characters, but Nuklear expects one spacing to be
+        // counter for every character in the string:
+        return MeasureTextEx(*(Font*)handle.ptr, subtext, height, height / 10.0f).x + height / 10.0f;
     }
 
     return 0;


### PR DESCRIPTION
RayLib seems to only measure the spacing *between* glyphs:

https://github.com/raysan5/raylib/blob/master/src/rtext.c#L1295

While Nuklear iterates over each glyph from the edit_string when trying to calculate the cursor position calling the width function for each char of the input:

https://github.com/vurtun/nuklear/blob/master/src/nuklear_util.c#L1105

That means we need to add one additional spacing when returning the width to compensate for the missing spacing from RayLib.

Closes #53