### PR TITLE
Fix context memory leak

### DIFF
--- a/include/raylib-nuklear.h
+++ b/include/raylib-nuklear.h
@@ -763,7 +763,7 @@ UnloadNuklear(struct nk_context * ctx)
 
     // Unload the nuklear context.
     nk_free(ctx);
-	 MemFree(ctx);
+    MemFree(ctx);
     TraceLog(LOG_INFO, "NUKLEAR: Unloaded GUI");
 }
 

--- a/include/raylib-nuklear.h
+++ b/include/raylib-nuklear.h
@@ -763,6 +763,7 @@ UnloadNuklear(struct nk_context * ctx)
 
     // Unload the nuklear context.
     nk_free(ctx);
+	 MemFree(ctx);
     TraceLog(LOG_INFO, "NUKLEAR: Unloaded GUI");
 }
 


### PR DESCRIPTION
nuklear context is `MemAlloc`'d in `InitNuklearContext` but never freed anywhere.  this just adds a `MemFree` to `UnloadNuklear`