### PR TITLE
Use DrawRectangleRoundedLinesEx and update nuklear

### DIFF
--- a/include/raylib-nuklear.h
+++ b/include/raylib-nuklear.h
@@ -448,7 +448,11 @@ DrawNuklear(struct nk_context * ctx)
                     rect.y += ((float) r->line_thickness) * scale + 1.0;
                     rect.width = NK_MAX(rect.width - (2 * ((float) r->line_thickness) * scale + 1.0), 0.0);
                     rect.height = NK_MAX(rect.height - (2 * ((float) r->line_thickness) * scale + 1.0), 0.0);
+#if RAYLIB_VERSION_MAJOR >= 5 && RAYLIB_VERSION_MINOR == 0
+                    DrawRectangleRoundedLines(rect, roundness, RAYLIB_NUKLEAR_DEFAULT_ARC_SEGMENTS, (float)r->line_thickness * scale, color);
+#else
                     DrawRectangleRoundedLinesEx(rect, roundness, RAYLIB_NUKLEAR_DEFAULT_ARC_SEGMENTS, (float)r->line_thickness * scale, color);
+#endif
                 }
                 else {
                     DrawRectangleLinesEx(rect, r->line_thickness * scale, color);

--- a/include/raylib-nuklear.h
+++ b/include/raylib-nuklear.h
@@ -448,7 +448,7 @@ DrawNuklear(struct nk_context * ctx)
                     rect.y += ((float) r->line_thickness) * scale + 1.0;
                     rect.width = NK_MAX(rect.width - (2 * ((float) r->line_thickness) * scale + 1.0), 0.0);
                     rect.height = NK_MAX(rect.height - (2 * ((float) r->line_thickness) * scale + 1.0), 0.0);
-                    DrawRectangleRoundedLines(rect, roundness, RAYLIB_NUKLEAR_DEFAULT_ARC_SEGMENTS, (float)r->line_thickness * scale, color);
+                    DrawRectangleRoundedLinesEx(rect, roundness, RAYLIB_NUKLEAR_DEFAULT_ARC_SEGMENTS, (float)r->line_thickness * scale, color);
                 }
                 else {
                     DrawRectangleLinesEx(rect, r->line_thickness * scale, color);


### PR DESCRIPTION
As of https://github.com/raysan5/raylib/commit/b51f4db8c29eba3506e953b351bedbf41f2a5c95 the method signature of `DrawRectangleRoundedLines` has changed.  The method with the added `Ex` suffix has the old signature.