### PR TITLE
Update raylib-nuklear.h

### DIFF
--- a/include/raylib-nuklear.h
+++ b/include/raylib-nuklear.h
@@ -63,6 +63,7 @@ NK_API struct nk_context* InitNuklear(int fontSize);                // Initializ
 NK_API struct nk_context* InitNuklearEx(Font font, float fontSize); // Initialize the Nuklear GUI context, with a custom font
 NK_API Font LoadFontFromNuklear(int fontSize);                      // Loads the default Nuklear font
 NK_API void UpdateNuklear(struct nk_context * ctx);                 // Update the input state and internal components for Nuklear
+NK_API void UpdateNuklearCustom(struct nk_context * ctx, float deltaTime); // Update the input state and internal components for Nuklear
 NK_API void DrawNuklear(struct nk_context * ctx);                   // Render the Nuklear GUI on the screen
 NK_API void UnloadNuklear(struct nk_context * ctx);                 // Deinitialize the Nuklear context
 NK_API struct nk_color ColorToNuklear(Color color);                 // Convert a raylib Color to a Nuklear color object
@@ -851,6 +852,27 @@ UpdateNuklear(struct nk_context * ctx)
 {
     // Update the time that has changed since last frame.
     ctx->delta_time_seconds = GetFrameTime();
+
+    // Update the input state.
+    nk_input_begin(ctx);
+    {
+        nk_raylib_input_mouse(ctx);
+        nk_raylib_input_keyboard(ctx);
+    }
+    nk_input_end(ctx);
+}
+
+/**
+ * Update the Nuklear context for raylib's state.
+ *
+ * @param ctx The nuklear context to act upon.
+ * @param deltaTime Time in seconds since last frame.
+ */
+NK_API void
+UpdateNuklearCustom(struct nk_context * ctx, float deltaTime)
+{
+    // Update the time that has changed since last frame.
+    ctx->delta_time_seconds = deltaTime;
 
     // Update the input state.
     nk_input_begin(ctx);


### PR DESCRIPTION
When building raylib with the flag SUPPORT_CUSTOM_FRAME_CONTROL, the function GetFrameTime becomes broken.

So I propose including a variation of UpdateNuklear that does not depend on GetFrameTime.