### PR TITLE
Remove extra nk__begin() call

### DIFF
--- a/examples/raylib-nuklear-texture.c
+++ b/examples/raylib-nuklear-texture.c
@@ -42,7 +42,7 @@ int main(void)
 			// Draw the image
 			nk_image(ctx, img);
 		}
-		nk_end(ctx);
+        nk_end(ctx);
 
 		// Draw the GUI
 		BeginDrawing();

--- a/include/raylib-nuklear.h
+++ b/include/raylib-nuklear.h
@@ -460,7 +460,7 @@ NK_API void
 DrawNuklear(struct nk_context * ctx)
 {
     // Protect against drawing when there's nothing to draw.
-    if (ctx == NULL || nk__begin(ctx) == 0) {
+    if (ctx == NULL) {
         return;
     }
 


### PR DESCRIPTION
Fixes  https://github.com/RobLoach/raylib-nuklear/issues/85

@lunarlattice0 Found an extra nk__begin() call, which I don't think we actually need. Mind testing?