### PR TITLE
Add NuklearKeyToKeyboardKey and KeyboardKeyToNuklearKey helpers

### DIFF
--- a/include/raylib-nuklear.h
+++ b/include/raylib-nuklear.h
@@ -1124,12 +1124,12 @@ GetNuklearScaling(struct nk_context * ctx)
 NK_API KeyboardKey
 NuklearKeyToKeyboardKey(nk_rune key)
 {
-    if (key == 0) return KEY_NULL;
+    if (key == 0 || key == (nk_rune)NK_KEY_MAX) return KEY_NULL;
     if (key < (nk_rune)NK_KEY_MAX) {
         switch ((enum nk_keys)key) {
             case NK_KEY_ENTER:           return KEY_ENTER;
             case NK_KEY_TAB:             return KEY_TAB;
-            case NK_KEY_SHIFT:           return KEY_LEFT_SHIFT;
+            case NK_KEY_SHIFT:           return KEY_LEFT_SHIFT; // KEY_RIGHT_SHIFT also maps to NK_KEY_SHIFT but is not reversible
             case NK_KEY_BACKSPACE:       return KEY_BACKSPACE;
             case NK_KEY_TEXT_RESET_MODE: return KEY_ESCAPE;
             case NK_KEY_DEL:             return KEY_DELETE;

--- a/include/raylib-nuklear.h
+++ b/include/raylib-nuklear.h
@@ -1189,7 +1189,7 @@ KeyboardKeyToNuklearKey(KeyboardKey key)
         case KEY_ENTER:         return (nk_rune)NK_KEY_ENTER;
         case KEY_TAB:           return (nk_rune)NK_KEY_TAB;
         case KEY_LEFT_SHIFT:
-        case KEY_RIGHT_SHIFT:   return (nk_rune)NK_KEY_SHIFT;
+        case KEY_RIGHT_SHIFT:   return (nk_rune)NK_KEY_SHIFT; // Both map to NK_KEY_SHIFT; NuklearKeyToKeyboardKey returns only KEY_LEFT_SHIFT
         case KEY_BACKSPACE:     return (nk_rune)NK_KEY_BACKSPACE;
         case KEY_ESCAPE:        return (nk_rune)NK_KEY_TEXT_RESET_MODE;
         case KEY_DELETE:        return (nk_rune)NK_KEY_DEL;

--- a/include/raylib-nuklear.h
+++ b/include/raylib-nuklear.h
@@ -88,8 +88,8 @@ NK_API struct nk_rect RectangleToNuklearRect(struct nk_context * ctx, Rectangle 
 NK_API struct nk_image TextureToNuklearImage(Texture texture);               // Get a Nuklear image from a Texture
 NK_API void SetNuklearScaling(struct nk_context * ctx, float scaling); // Sets the scaling for the given Nuklear context
 NK_API float GetNuklearScaling(struct nk_context * ctx);            // Retrieves the scaling of the given Nuklear context
-NK_API KeyboardKey NkKeyToKeyboardKey(nk_rune key);                 // Convert an nk_rune key binding to a raylib KeyboardKey
-NK_API nk_rune KeyboardKeyToNkKey(KeyboardKey key);                 // Convert a raylib KeyboardKey to an nk_rune key binding
+NK_API KeyboardKey NuklearKeyToKeyboardKey(nk_rune key);                 // Convert an nk_rune key binding to a raylib KeyboardKey
+NK_API nk_rune KeyboardKeyToNuklearKey(KeyboardKey key);                 // Convert a raylib KeyboardKey to an nk_rune key binding
 
 // Internal Nuklear functions
 NK_API float nk_raylib_font_get_text_width(nk_handle handle, float height, const char *text, int len);
@@ -1122,7 +1122,7 @@ GetNuklearScaling(struct nk_context * ctx)
  * Convert an nk_rune key binding to a raylib KeyboardKey.
  */
 NK_API KeyboardKey
-NkKeyToKeyboardKey(nk_rune key)
+NuklearKeyToKeyboardKey(nk_rune key)
 {
     if (key == 0) return KEY_NULL;
     if (key < (nk_rune)NK_KEY_MAX) {
@@ -1183,7 +1183,7 @@ NkKeyToKeyboardKey(nk_rune key)
  * Convert a raylib KeyboardKey to an nk_rune key binding.
  */
 NK_API nk_rune
-KeyboardKeyToNkKey(KeyboardKey key)
+KeyboardKeyToNuklearKey(KeyboardKey key)
 {
     switch (key) {
         case KEY_ENTER:         return (nk_rune)NK_KEY_ENTER;

--- a/include/raylib-nuklear.h
+++ b/include/raylib-nuklear.h
@@ -88,6 +88,8 @@ NK_API struct nk_rect RectangleToNuklearRect(struct nk_context * ctx, Rectangle 
 NK_API struct nk_image TextureToNuklearImage(Texture texture);               // Get a Nuklear image from a Texture
 NK_API void SetNuklearScaling(struct nk_context * ctx, float scaling); // Sets the scaling for the given Nuklear context
 NK_API float GetNuklearScaling(struct nk_context * ctx);            // Retrieves the scaling of the given Nuklear context
+NK_API KeyboardKey NkKeyToKeyboardKey(nk_rune key);                 // Convert an nk_rune key binding to a raylib KeyboardKey
+NK_API nk_rune KeyboardKeyToNkKey(KeyboardKey key);                 // Convert a raylib KeyboardKey to an nk_rune key binding
 
 // Internal Nuklear functions
 NK_API float nk_raylib_font_get_text_width(nk_handle handle, float height, const char *text, int len);
@@ -1114,6 +1116,101 @@ GetNuklearScaling(struct nk_context * ctx)
     }
 
     return 1.0f;
+}
+
+/**
+ * Convert an nk_rune key binding to a raylib KeyboardKey.
+ */
+NK_API KeyboardKey
+NkKeyToKeyboardKey(nk_rune key)
+{
+    if (key == 0) return KEY_NULL;
+    if (key < (nk_rune)NK_KEY_MAX) {
+        switch ((enum nk_keys)key) {
+            case NK_KEY_ENTER:           return KEY_ENTER;
+            case NK_KEY_TAB:             return KEY_TAB;
+            case NK_KEY_SHIFT:           return KEY_LEFT_SHIFT;
+            case NK_KEY_BACKSPACE:       return KEY_BACKSPACE;
+            case NK_KEY_TEXT_RESET_MODE: return KEY_ESCAPE;
+            case NK_KEY_DEL:             return KEY_DELETE;
+            case NK_KEY_UP:              return KEY_UP;
+            case NK_KEY_DOWN:            return KEY_DOWN;
+            case NK_KEY_LEFT:            return KEY_LEFT;
+            case NK_KEY_RIGHT:           return KEY_RIGHT;
+            case NK_KEY_F1:              return KEY_F1;
+            case NK_KEY_F2:              return KEY_F2;
+            case NK_KEY_F3:              return KEY_F3;
+            case NK_KEY_F4:              return KEY_F4;
+            case NK_KEY_F5:              return KEY_F5;
+            case NK_KEY_F6:              return KEY_F6;
+            case NK_KEY_F7:              return KEY_F7;
+            case NK_KEY_F8:              return KEY_F8;
+            case NK_KEY_F9:              return KEY_F9;
+            case NK_KEY_F10:             return KEY_F10;
+            case NK_KEY_F11:             return KEY_F11;
+            case NK_KEY_F12:             return KEY_F12;
+            default:                     return KEY_NULL;
+        }
+    }
+    if (key >= 'a' && key <= 'z') key -= 32;
+    switch (key) {
+        case '+': return KEY_EQUAL;
+        case '_': return KEY_MINUS;
+        case '?': return KEY_SLASH;
+        case ':': return KEY_SEMICOLON;
+        case '"': return KEY_APOSTROPHE;
+        case '<': return KEY_COMMA;
+        case '>': return KEY_PERIOD;
+        case '{': return KEY_LEFT_BRACKET;
+        case '}': return KEY_RIGHT_BRACKET;
+        case '|': return KEY_BACKSLASH;
+        case '~': return KEY_GRAVE;
+        case '!': return KEY_ONE;
+        case '@': return KEY_TWO;
+        case '#': return KEY_THREE;
+        case '$': return KEY_FOUR;
+        case '%': return KEY_FIVE;
+        case '^': return KEY_SIX;
+        case '&': return KEY_SEVEN;
+        case '*': return KEY_EIGHT;
+        case '(': return KEY_NINE;
+        case ')': return KEY_ZERO;
+    }
+    return (KeyboardKey)(int)key;
+}
+
+/**
+ * Convert a raylib KeyboardKey to an nk_rune key binding.
+ */
+NK_API nk_rune
+KeyboardKeyToNkKey(KeyboardKey key)
+{
+    switch (key) {
+        case KEY_ENTER:         return (nk_rune)NK_KEY_ENTER;
+        case KEY_TAB:           return (nk_rune)NK_KEY_TAB;
+        case KEY_LEFT_SHIFT:
+        case KEY_RIGHT_SHIFT:   return (nk_rune)NK_KEY_SHIFT;
+        case KEY_BACKSPACE:     return (nk_rune)NK_KEY_BACKSPACE;
+        case KEY_ESCAPE:        return (nk_rune)NK_KEY_TEXT_RESET_MODE;
+        case KEY_DELETE:        return (nk_rune)NK_KEY_DEL;
+        case KEY_UP:            return (nk_rune)NK_KEY_UP;
+        case KEY_DOWN:          return (nk_rune)NK_KEY_DOWN;
+        case KEY_LEFT:          return (nk_rune)NK_KEY_LEFT;
+        case KEY_RIGHT:         return (nk_rune)NK_KEY_RIGHT;
+        case KEY_F1:            return (nk_rune)NK_KEY_F1;
+        case KEY_F2:            return (nk_rune)NK_KEY_F2;
+        case KEY_F3:            return (nk_rune)NK_KEY_F3;
+        case KEY_F4:            return (nk_rune)NK_KEY_F4;
+        case KEY_F5:            return (nk_rune)NK_KEY_F5;
+        case KEY_F6:            return (nk_rune)NK_KEY_F6;
+        case KEY_F7:            return (nk_rune)NK_KEY_F7;
+        case KEY_F8:            return (nk_rune)NK_KEY_F8;
+        case KEY_F9:            return (nk_rune)NK_KEY_F9;
+        case KEY_F10:           return (nk_rune)NK_KEY_F10;
+        case KEY_F11:           return (nk_rune)NK_KEY_F11;
+        case KEY_F12:           return (nk_rune)NK_KEY_F12;
+        default:                return (nk_rune)key;
+    }
 }
 
 #ifdef __cplusplus

--- a/test/raylib-nuklear-test.c
+++ b/test/raylib-nuklear-test.c
@@ -109,6 +109,51 @@ int main(int argc, char *argv[]) {
         UnloadNuklear(ctx);
     }
 
+    // NkKeyToKeyboardKey()
+    {
+        AssertEqual(NkKeyToKeyboardKey(0), KEY_NULL);
+        AssertEqual(NkKeyToKeyboardKey((nk_rune)NK_KEY_ENTER), KEY_ENTER);
+        AssertEqual(NkKeyToKeyboardKey((nk_rune)NK_KEY_TAB), KEY_TAB);
+        AssertEqual(NkKeyToKeyboardKey((nk_rune)NK_KEY_SHIFT), KEY_LEFT_SHIFT);
+        AssertEqual(NkKeyToKeyboardKey((nk_rune)NK_KEY_BACKSPACE), KEY_BACKSPACE);
+        AssertEqual(NkKeyToKeyboardKey((nk_rune)NK_KEY_TEXT_RESET_MODE), KEY_ESCAPE);
+        AssertEqual(NkKeyToKeyboardKey((nk_rune)NK_KEY_DEL), KEY_DELETE);
+        AssertEqual(NkKeyToKeyboardKey((nk_rune)NK_KEY_UP), KEY_UP);
+        AssertEqual(NkKeyToKeyboardKey((nk_rune)NK_KEY_DOWN), KEY_DOWN);
+        AssertEqual(NkKeyToKeyboardKey((nk_rune)NK_KEY_LEFT), KEY_LEFT);
+        AssertEqual(NkKeyToKeyboardKey((nk_rune)NK_KEY_RIGHT), KEY_RIGHT);
+        AssertEqual(NkKeyToKeyboardKey((nk_rune)NK_KEY_F1), KEY_F1);
+        AssertEqual(NkKeyToKeyboardKey((nk_rune)NK_KEY_F6), KEY_F6);
+        AssertEqual(NkKeyToKeyboardKey((nk_rune)NK_KEY_F12), KEY_F12);
+        AssertEqual(NkKeyToKeyboardKey('A'), KEY_A);
+        AssertEqual(NkKeyToKeyboardKey('a'), KEY_A);
+        AssertEqual(NkKeyToKeyboardKey('Z'), KEY_Z);
+        AssertEqual(NkKeyToKeyboardKey('!'), KEY_ONE);
+        AssertEqual(NkKeyToKeyboardKey('@'), KEY_TWO);
+        AssertEqual(NkKeyToKeyboardKey('+'), KEY_EQUAL);
+        AssertEqual(NkKeyToKeyboardKey('_'), KEY_MINUS);
+    }
+
+    // KeyboardKeyToNkKey()
+    {
+        AssertEqual(KeyboardKeyToNkKey(KEY_ENTER), (nk_rune)NK_KEY_ENTER);
+        AssertEqual(KeyboardKeyToNkKey(KEY_TAB), (nk_rune)NK_KEY_TAB);
+        AssertEqual(KeyboardKeyToNkKey(KEY_LEFT_SHIFT), (nk_rune)NK_KEY_SHIFT);
+        AssertEqual(KeyboardKeyToNkKey(KEY_RIGHT_SHIFT), (nk_rune)NK_KEY_SHIFT);
+        AssertEqual(KeyboardKeyToNkKey(KEY_BACKSPACE), (nk_rune)NK_KEY_BACKSPACE);
+        AssertEqual(KeyboardKeyToNkKey(KEY_ESCAPE), (nk_rune)NK_KEY_TEXT_RESET_MODE);
+        AssertEqual(KeyboardKeyToNkKey(KEY_DELETE), (nk_rune)NK_KEY_DEL);
+        AssertEqual(KeyboardKeyToNkKey(KEY_UP), (nk_rune)NK_KEY_UP);
+        AssertEqual(KeyboardKeyToNkKey(KEY_DOWN), (nk_rune)NK_KEY_DOWN);
+        AssertEqual(KeyboardKeyToNkKey(KEY_LEFT), (nk_rune)NK_KEY_LEFT);
+        AssertEqual(KeyboardKeyToNkKey(KEY_RIGHT), (nk_rune)NK_KEY_RIGHT);
+        AssertEqual(KeyboardKeyToNkKey(KEY_F1), (nk_rune)NK_KEY_F1);
+        AssertEqual(KeyboardKeyToNkKey(KEY_F6), (nk_rune)NK_KEY_F6);
+        AssertEqual(KeyboardKeyToNkKey(KEY_F12), (nk_rune)NK_KEY_F12);
+        AssertEqual(KeyboardKeyToNkKey(KEY_A), (nk_rune)KEY_A);
+        AssertEqual(KeyboardKeyToNkKey(KEY_Z), (nk_rune)KEY_Z);
+    }
+
     CloseWindow();
     TraceLog(LOG_INFO, "================================");
     TraceLog(LOG_INFO, "raylib-nuklear tests succesful");

--- a/test/raylib-nuklear-test.c
+++ b/test/raylib-nuklear-test.c
@@ -109,49 +109,49 @@ int main(int argc, char *argv[]) {
         UnloadNuklear(ctx);
     }
 
-    // NkKeyToKeyboardKey()
+    // NuklearKeyToKeyboardKey()
     {
-        AssertEqual(NkKeyToKeyboardKey(0), KEY_NULL);
-        AssertEqual(NkKeyToKeyboardKey((nk_rune)NK_KEY_ENTER), KEY_ENTER);
-        AssertEqual(NkKeyToKeyboardKey((nk_rune)NK_KEY_TAB), KEY_TAB);
-        AssertEqual(NkKeyToKeyboardKey((nk_rune)NK_KEY_SHIFT), KEY_LEFT_SHIFT);
-        AssertEqual(NkKeyToKeyboardKey((nk_rune)NK_KEY_BACKSPACE), KEY_BACKSPACE);
-        AssertEqual(NkKeyToKeyboardKey((nk_rune)NK_KEY_TEXT_RESET_MODE), KEY_ESCAPE);
-        AssertEqual(NkKeyToKeyboardKey((nk_rune)NK_KEY_DEL), KEY_DELETE);
-        AssertEqual(NkKeyToKeyboardKey((nk_rune)NK_KEY_UP), KEY_UP);
-        AssertEqual(NkKeyToKeyboardKey((nk_rune)NK_KEY_DOWN), KEY_DOWN);
-        AssertEqual(NkKeyToKeyboardKey((nk_rune)NK_KEY_LEFT), KEY_LEFT);
-        AssertEqual(NkKeyToKeyboardKey((nk_rune)NK_KEY_RIGHT), KEY_RIGHT);
-        AssertEqual(NkKeyToKeyboardKey((nk_rune)NK_KEY_F1), KEY_F1);
-        AssertEqual(NkKeyToKeyboardKey((nk_rune)NK_KEY_F6), KEY_F6);
-        AssertEqual(NkKeyToKeyboardKey((nk_rune)NK_KEY_F12), KEY_F12);
-        AssertEqual(NkKeyToKeyboardKey('A'), KEY_A);
-        AssertEqual(NkKeyToKeyboardKey('a'), KEY_A);
-        AssertEqual(NkKeyToKeyboardKey('Z'), KEY_Z);
-        AssertEqual(NkKeyToKeyboardKey('!'), KEY_ONE);
-        AssertEqual(NkKeyToKeyboardKey('@'), KEY_TWO);
-        AssertEqual(NkKeyToKeyboardKey('+'), KEY_EQUAL);
-        AssertEqual(NkKeyToKeyboardKey('_'), KEY_MINUS);
+        AssertEqual(NuklearKeyToKeyboardKey(0), KEY_NULL);
+        AssertEqual(NuklearKeyToKeyboardKey((nk_rune)NK_KEY_ENTER), KEY_ENTER);
+        AssertEqual(NuklearKeyToKeyboardKey((nk_rune)NK_KEY_TAB), KEY_TAB);
+        AssertEqual(NuklearKeyToKeyboardKey((nk_rune)NK_KEY_SHIFT), KEY_LEFT_SHIFT);
+        AssertEqual(NuklearKeyToKeyboardKey((nk_rune)NK_KEY_BACKSPACE), KEY_BACKSPACE);
+        AssertEqual(NuklearKeyToKeyboardKey((nk_rune)NK_KEY_TEXT_RESET_MODE), KEY_ESCAPE);
+        AssertEqual(NuklearKeyToKeyboardKey((nk_rune)NK_KEY_DEL), KEY_DELETE);
+        AssertEqual(NuklearKeyToKeyboardKey((nk_rune)NK_KEY_UP), KEY_UP);
+        AssertEqual(NuklearKeyToKeyboardKey((nk_rune)NK_KEY_DOWN), KEY_DOWN);
+        AssertEqual(NuklearKeyToKeyboardKey((nk_rune)NK_KEY_LEFT), KEY_LEFT);
+        AssertEqual(NuklearKeyToKeyboardKey((nk_rune)NK_KEY_RIGHT), KEY_RIGHT);
+        AssertEqual(NuklearKeyToKeyboardKey((nk_rune)NK_KEY_F1), KEY_F1);
+        AssertEqual(NuklearKeyToKeyboardKey((nk_rune)NK_KEY_F6), KEY_F6);
+        AssertEqual(NuklearKeyToKeyboardKey((nk_rune)NK_KEY_F12), KEY_F12);
+        AssertEqual(NuklearKeyToKeyboardKey('A'), KEY_A);
+        AssertEqual(NuklearKeyToKeyboardKey('a'), KEY_A);
+        AssertEqual(NuklearKeyToKeyboardKey('Z'), KEY_Z);
+        AssertEqual(NuklearKeyToKeyboardKey('!'), KEY_ONE);
+        AssertEqual(NuklearKeyToKeyboardKey('@'), KEY_TWO);
+        AssertEqual(NuklearKeyToKeyboardKey('+'), KEY_EQUAL);
+        AssertEqual(NuklearKeyToKeyboardKey('_'), KEY_MINUS);
     }
 
-    // KeyboardKeyToNkKey()
+    // KeyboardKeyToNuklearKey()
     {
-        AssertEqual(KeyboardKeyToNkKey(KEY_ENTER), (nk_rune)NK_KEY_ENTER);
-        AssertEqual(KeyboardKeyToNkKey(KEY_TAB), (nk_rune)NK_KEY_TAB);
-        AssertEqual(KeyboardKeyToNkKey(KEY_LEFT_SHIFT), (nk_rune)NK_KEY_SHIFT);
-        AssertEqual(KeyboardKeyToNkKey(KEY_RIGHT_SHIFT), (nk_rune)NK_KEY_SHIFT);
-        AssertEqual(KeyboardKeyToNkKey(KEY_BACKSPACE), (nk_rune)NK_KEY_BACKSPACE);
-        AssertEqual(KeyboardKeyToNkKey(KEY_ESCAPE), (nk_rune)NK_KEY_TEXT_RESET_MODE);
-        AssertEqual(KeyboardKeyToNkKey(KEY_DELETE), (nk_rune)NK_KEY_DEL);
-        AssertEqual(KeyboardKeyToNkKey(KEY_UP), (nk_rune)NK_KEY_UP);
-        AssertEqual(KeyboardKeyToNkKey(KEY_DOWN), (nk_rune)NK_KEY_DOWN);
-        AssertEqual(KeyboardKeyToNkKey(KEY_LEFT), (nk_rune)NK_KEY_LEFT);
-        AssertEqual(KeyboardKeyToNkKey(KEY_RIGHT), (nk_rune)NK_KEY_RIGHT);
-        AssertEqual(KeyboardKeyToNkKey(KEY_F1), (nk_rune)NK_KEY_F1);
-        AssertEqual(KeyboardKeyToNkKey(KEY_F6), (nk_rune)NK_KEY_F6);
-        AssertEqual(KeyboardKeyToNkKey(KEY_F12), (nk_rune)NK_KEY_F12);
-        AssertEqual(KeyboardKeyToNkKey(KEY_A), (nk_rune)KEY_A);
-        AssertEqual(KeyboardKeyToNkKey(KEY_Z), (nk_rune)KEY_Z);
+        AssertEqual(KeyboardKeyToNuklearKey(KEY_ENTER), (nk_rune)NK_KEY_ENTER);
+        AssertEqual(KeyboardKeyToNuklearKey(KEY_TAB), (nk_rune)NK_KEY_TAB);
+        AssertEqual(KeyboardKeyToNuklearKey(KEY_LEFT_SHIFT), (nk_rune)NK_KEY_SHIFT);
+        AssertEqual(KeyboardKeyToNuklearKey(KEY_RIGHT_SHIFT), (nk_rune)NK_KEY_SHIFT);
+        AssertEqual(KeyboardKeyToNuklearKey(KEY_BACKSPACE), (nk_rune)NK_KEY_BACKSPACE);
+        AssertEqual(KeyboardKeyToNuklearKey(KEY_ESCAPE), (nk_rune)NK_KEY_TEXT_RESET_MODE);
+        AssertEqual(KeyboardKeyToNuklearKey(KEY_DELETE), (nk_rune)NK_KEY_DEL);
+        AssertEqual(KeyboardKeyToNuklearKey(KEY_UP), (nk_rune)NK_KEY_UP);
+        AssertEqual(KeyboardKeyToNuklearKey(KEY_DOWN), (nk_rune)NK_KEY_DOWN);
+        AssertEqual(KeyboardKeyToNuklearKey(KEY_LEFT), (nk_rune)NK_KEY_LEFT);
+        AssertEqual(KeyboardKeyToNuklearKey(KEY_RIGHT), (nk_rune)NK_KEY_RIGHT);
+        AssertEqual(KeyboardKeyToNuklearKey(KEY_F1), (nk_rune)NK_KEY_F1);
+        AssertEqual(KeyboardKeyToNuklearKey(KEY_F6), (nk_rune)NK_KEY_F6);
+        AssertEqual(KeyboardKeyToNuklearKey(KEY_F12), (nk_rune)NK_KEY_F12);
+        AssertEqual(KeyboardKeyToNuklearKey(KEY_A), (nk_rune)KEY_A);
+        AssertEqual(KeyboardKeyToNuklearKey(KEY_Z), (nk_rune)KEY_Z);
     }
 
     CloseWindow();


### PR DESCRIPTION
Adds helper functions to convert between nk_rune/nk_keys and raylib KeyboardKey in both directions. Fixes #100