### PR TITLE
input: add double-click support

### DIFF
--- a/include/raylib-nuklear.h
+++ b/include/raylib-nuklear.h
@@ -158,6 +158,15 @@ extern "C" {
 #define RAYLIB_NUKLEAR_DEFAULT_ARC_SEGMENTS 20
 #endif  // RAYLIB_NUKLEAR_DEFAULT_ARC_SEGMENTS
 
+#ifndef RAYLIB_NUKLEAR_DOUBLE_CLICK_THRESHOLD
+/**
+ * The amount of time required to wait to determine a mouse click as a double click.
+ *
+ * @see nk_raylib_input_mouse()
+ */
+#define RAYLIB_NUKLEAR_DOUBLE_CLICK_THRESHOLD 0.3
+#endif  // RAYLIB_NUKLEAR_DOUBLE_CLICK_THRESHOLD
+
 /**
  * The user data that's leverages internally through Nuklear.
  */
@@ -950,14 +959,13 @@ nk_raylib_input_mouse(struct nk_context * ctx)
     nk_input_button(ctx, NK_BUTTON_X1, mouseX, mouseY, IsMouseButtonDown(MOUSE_BUTTON_SIDE));
     nk_input_button(ctx, NK_BUTTON_X2, mouseX, mouseY, IsMouseButtonDown(MOUSE_BUTTON_EXTRA));
 
-    // Double-click: track time between left presses; signal NK_BUTTON_DOUBLE within threshold.
+    // Double Click
     {
         static double lastLeftPressTime = 0.0;
         static nk_bool doubleClicking = nk_false;
-        const double doubleClickThreshold = 0.3;
         if (IsMouseButtonPressed(MOUSE_LEFT_BUTTON)) {
             double now = GetTime();
-            doubleClicking = (now - lastLeftPressTime <= doubleClickThreshold) ? nk_true : nk_false;
+            doubleClicking = (now - lastLeftPressTime <= RAYLIB_NUKLEAR_DOUBLE_CLICK_THRESHOLD) ? nk_true : nk_false;
             lastLeftPressTime = now;
         }
         else if (IsMouseButtonReleased(MOUSE_LEFT_BUTTON)) {

--- a/include/raylib-nuklear.h
+++ b/include/raylib-nuklear.h
@@ -950,6 +950,22 @@ nk_raylib_input_mouse(struct nk_context * ctx)
     nk_input_button(ctx, NK_BUTTON_X1, mouseX, mouseY, IsMouseButtonDown(MOUSE_BUTTON_SIDE));
     nk_input_button(ctx, NK_BUTTON_X2, mouseX, mouseY, IsMouseButtonDown(MOUSE_BUTTON_EXTRA));
 
+    // Double-click: track time between left presses; signal NK_BUTTON_DOUBLE within threshold.
+    {
+        static double lastLeftPressTime = 0.0;
+        static nk_bool doubleClicking = nk_false;
+        const double doubleClickThreshold = 0.3;
+        if (IsMouseButtonPressed(MOUSE_LEFT_BUTTON)) {
+            double now = GetTime();
+            doubleClicking = (now - lastLeftPressTime <= doubleClickThreshold) ? nk_true : nk_false;
+            lastLeftPressTime = now;
+        }
+        else if (IsMouseButtonReleased(MOUSE_LEFT_BUTTON)) {
+            doubleClicking = nk_false;
+        }
+        nk_input_button(ctx, NK_BUTTON_DOUBLE, mouseX, mouseY, doubleClicking);
+    }
+
     // Mouse Wheel
     float mouseWheel = GetMouseWheelMove();
     if (mouseWheel != 0.0f) {


### PR DESCRIPTION
Tracks left mouse press timing in nk_raylib_input_mouse() and signals NK_BUTTON_DOUBLE to Nuklear when two presses occur within 300ms, implementing double-click support. Fixes #102