### PR TITLE
Export CMake package config for find_package() support

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,17 @@ There are a few other graphical user interface solutions out there for use with 
 | Industry Standard | :x: | :x: | :white_check_mark: |
 | Easy to Use | :x: | :white_check_mark: | :x: |
 
+## CMake Integration
+
+After installing via `cmake --install`, use `find_package` in your project:
+
+```cmake
+find_package(raylib-nuklear REQUIRED)
+target_link_libraries(my_app PRIVATE raylib-nuklear::raylib-nuklear)
+```
+
+Alternatively, add as a subdirectory or use `FetchContent` and link against `raylib_nuklear`.
+
 ## Development
 
 While this project uses CMake, CMake is not required in order to use *raylib-nuklear*.

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,8 +1,45 @@
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
 # raylib_nuklear
 add_library(raylib_nuklear INTERFACE)
-target_include_directories(raylib_nuklear INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+add_library(raylib-nuklear::raylib-nuklear ALIAS raylib_nuklear)
+
+target_include_directories(raylib_nuklear INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
 install(FILES
     raylib-nuklear.h
     nuklear.h
-    DESTINATION include
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+install(TARGETS raylib_nuklear
+    EXPORT raylib-nuklearTargets
+)
+
+install(EXPORT raylib-nuklearTargets
+    FILE raylib-nuklearTargets.cmake
+    NAMESPACE raylib-nuklear::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/raylib-nuklear
+)
+
+configure_package_config_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/raylib-nuklearConfig.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/raylib-nuklearConfig.cmake"
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/raylib-nuklear
+)
+
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/raylib-nuklearConfigVersion.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/raylib-nuklearConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/raylib-nuklearConfigVersion.cmake"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/raylib-nuklear
 )

--- a/include/raylib-nuklearConfig.cmake.in
+++ b/include/raylib-nuklearConfig.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/raylib-nuklearTargets.cmake")
+
+check_required_components(raylib-nuklear)


### PR DESCRIPTION
Generates `raylib-nuklearConfig.cmake` and version file on install, adds a namespace alias, and documents the `find_package` flow in the README. Fixes #106