### PR TITLE
Emit NK_COMMAND_CUSTOM warning at most once per context lifetime

### DIFF
--- a/include/raylib-nuklear.h
+++ b/include/raylib-nuklear.h
@@ -172,7 +172,6 @@ extern "C" {
  */
 typedef struct NuklearUserData {
     float scaling; // The scaling of the Nuklear user interface.
-    bool customCommandWarned; // Whether the NK_COMMAND_CUSTOM warning has already been emitted.
 } NuklearUserData;
 
 /**
@@ -613,7 +612,6 @@ DrawNuklear(struct nk_context * ctx)
 
     const struct nk_command *cmd;
     const float scale = GetNuklearScaling(ctx);
-    struct NuklearUserData* userData = (struct NuklearUserData*)ctx->userdata.ptr;
 
     nk_foreach(cmd, ctx) {
         switch (cmd->type) {
@@ -829,9 +827,10 @@ DrawNuklear(struct nk_context * ctx)
             } break;
 
             case NK_COMMAND_CUSTOM: {
-                if (userData != NULL && !userData->customCommandWarned) {
+                static bool nk_command_custom_warned = false;
+                if (userData != NULL && !nk_command_custom_warned) {
                     TraceLog(LOG_WARNING, "NUKLEAR: Unverified custom callback implementation NK_COMMAND_CUSTOM");
-                    userData->customCommandWarned = true;
+                    nk_command_custom_warned = true;
                 }
                 const struct nk_command_custom *custom = (const struct nk_command_custom *)cmd;
                 custom->callback(NULL, (short)(custom->x * scale), (short)(custom->y * scale), (unsigned short)(custom->w * scale), (unsigned short)(custom->h * scale), custom->callback_data);

--- a/include/raylib-nuklear.h
+++ b/include/raylib-nuklear.h
@@ -172,6 +172,7 @@ extern "C" {
  */
 typedef struct NuklearUserData {
     float scaling; // The scaling of the Nuklear user interface.
+    bool customCommandWarned; // Whether the NK_COMMAND_CUSTOM warning has already been emitted.
 } NuklearUserData;
 
 /**
@@ -612,6 +613,7 @@ DrawNuklear(struct nk_context * ctx)
 
     const struct nk_command *cmd;
     const float scale = GetNuklearScaling(ctx);
+    struct NuklearUserData* userData = (struct NuklearUserData*)ctx->userdata.ptr;
 
     nk_foreach(cmd, ctx) {
         switch (cmd->type) {
@@ -827,7 +829,10 @@ DrawNuklear(struct nk_context * ctx)
             } break;
 
             case NK_COMMAND_CUSTOM: {
-                TraceLog(LOG_WARNING, "NUKLEAR: Unverified custom callback implementation NK_COMMAND_CUSTOM");
+                if (userData != NULL && !userData->customCommandWarned) {
+                    TraceLog(LOG_WARNING, "NUKLEAR: Unverified custom callback implementation NK_COMMAND_CUSTOM");
+                    userData->customCommandWarned = true;
+                }
                 const struct nk_command_custom *custom = (const struct nk_command_custom *)cmd;
                 custom->callback(NULL, (short)(custom->x * scale), (short)(custom->y * scale), (unsigned short)(custom->w * scale), (unsigned short)(custom->h * scale), custom->callback_data);
             } break;

--- a/include/raylib-nuklear.h
+++ b/include/raylib-nuklear.h
@@ -827,12 +827,6 @@ DrawNuklear(struct nk_context * ctx)
             } break;
 
             case NK_COMMAND_CUSTOM: {
-                static bool nk_command_custom_warned = false;
-
-                if (!nk_command_custom_warned) {
-                    TraceLog(LOG_WARNING, "NUKLEAR: Unverified custom callback implementation NK_COMMAND_CUSTOM");
-                    nk_command_custom_warned = true;
-                }
                 const struct nk_command_custom *custom = (const struct nk_command_custom *)cmd;
                 custom->callback(NULL, (short)(custom->x * scale), (short)(custom->y * scale), (unsigned short)(custom->w * scale), (unsigned short)(custom->h * scale), custom->callback_data);
             } break;

--- a/include/raylib-nuklear.h
+++ b/include/raylib-nuklear.h
@@ -828,7 +828,8 @@ DrawNuklear(struct nk_context * ctx)
 
             case NK_COMMAND_CUSTOM: {
                 static bool nk_command_custom_warned = false;
-                if (userData != NULL && !nk_command_custom_warned) {
+
+                if (!nk_command_custom_warned) {
                     TraceLog(LOG_WARNING, "NUKLEAR: Unverified custom callback implementation NK_COMMAND_CUSTOM");
                     nk_command_custom_warned = true;
                 }


### PR DESCRIPTION
Adds a `customCommandWarned` flag to `NuklearUserData` so the `NK_COMMAND_CUSTOM` warning is logged at most once per `InitNuklear()` call instead of every frame, preventing log spam for apps that use custom draw commands.

Fixes #115