### PR TITLE
Add Vector2 to nk_vec2 conversion

### DIFF
--- a/include/raylib-nuklear.h
+++ b/include/raylib-nuklear.h
@@ -86,6 +86,8 @@ NK_API struct Color NuklearColorFToColor(struct nk_colorf color);      // Conver
 NK_API struct Rectangle NuklearRectToRectangle(struct nk_context * ctx, struct nk_rect rect); // Convert a Nuklear rectangle to a raylib Rectangle
 NK_API struct nk_rect RectangleToNuklearRect(struct nk_context * ctx, Rectangle rect); // Convert a raylib Rectangle to a Nuklear Rectangle
 NK_API struct nk_image TextureToNuklearImage(Texture texture);               // Get a Nuklear image from a Texture
+NK_API struct nk_vec2 Vector2ToNuklearVec2(Vector2 vec);                     // Convert a raylib Vector2 to a Nuklear nk_vec2
+NK_API Vector2 NuklearVec2ToVector2(struct nk_vec2 vec);                     // Convert a Nuklear nk_vec2 to a raylib Vector2
 NK_API void SetNuklearScaling(struct nk_context * ctx, float scaling); // Sets the scaling for the given Nuklear context
 NK_API float GetNuklearScaling(struct nk_context * ctx);            // Retrieves the scaling of the given Nuklear context
 NK_API KeyboardKey NuklearKeyToKeyboardKey(nk_rune key);                 // Convert an nk_rune key binding to a raylib KeyboardKey
@@ -1099,6 +1101,19 @@ TextureToNuklearImage(Texture texture)
 	img.region[2] = img.w;
 	img.region[3] = img.h;
 	return img;
+}
+
+NK_API struct nk_vec2
+Vector2ToNuklearVec2(Vector2 vec)
+{
+    return nk_vec2(vec.x, vec.y);
+}
+
+NK_API Vector2
+NuklearVec2ToVector2(struct nk_vec2 vec)
+{
+    Vector2 v = { vec.x, vec.y };
+    return v;
 }
 
 /**

--- a/test/raylib-nuklear-test.c
+++ b/test/raylib-nuklear-test.c
@@ -109,6 +109,17 @@ int main(int argc, char *argv[]) {
         UnloadNuklear(ctx);
     }
 
+    // Vector2ToNuklearVec2() / NuklearVec2ToVector2() round-trip
+    {
+        Vector2 v = { 3.5f, 7.25f };
+        struct nk_vec2 nv = Vector2ToNuklearVec2(v);
+        AssertEqual(nv.x, v.x);
+        AssertEqual(nv.y, v.y);
+        Vector2 rt = NuklearVec2ToVector2(nv);
+        AssertEqual(rt.x, v.x);
+        AssertEqual(rt.y, v.y);
+    }
+
     // NuklearKeyToKeyboardKey()
     {
         AssertEqual(NuklearKeyToKeyboardKey(0), KEY_NULL);


### PR DESCRIPTION
Adds `Vector2ToNuklearVec2()` and `NuklearVec2ToVector2()` following the same pattern as the existing color and rectangle conversions, so callers no longer need to cast manually when working with scroll offsets, layout positions, or content sizes.

Fixes #114