### PR TITLE
Add RAYLIB_NUKLEAR_VERSION compile-time version macros

### DIFF
--- a/include/raylib-nuklear.h
+++ b/include/raylib-nuklear.h
@@ -36,6 +36,11 @@
 #ifndef RAYLIB_NUKLEAR_H
 #define RAYLIB_NUKLEAR_H
 
+#define RAYLIB_NUKLEAR_VERSION "6.0.1"
+#define RAYLIB_NUKLEAR_VERSION_MAJOR 6
+#define RAYLIB_NUKLEAR_VERSION_MINOR 0
+#define RAYLIB_NUKLEAR_VERSION_PATCH 1
+
 #include "raylib.h"
 
 // Nuklear defines

--- a/test/raylib-nuklear-test.c
+++ b/test/raylib-nuklear-test.c
@@ -206,9 +206,6 @@ int main(int argc, char *argv[]) {
     Assert(RAYLIB_NUKLEAR_VERSION_MAJOR >= 1);
     Assert(RAYLIB_NUKLEAR_VERSION_MINOR >= 0);
     Assert(RAYLIB_NUKLEAR_VERSION_PATCH >= 0);
-    #if RAYLIB_NUKLEAR_VERSION_MAJOR >= 6
-    Assert(1);
-    #endif
     Assert(TextIsEqual(RAYLIB_NUKLEAR_VERSION, "6.0.1"));
 
     CloseWindow();

--- a/test/raylib-nuklear-test.c
+++ b/test/raylib-nuklear-test.c
@@ -202,6 +202,15 @@ int main(int argc, char *argv[]) {
         UnloadNuklear(ctx);
     }
 
+    // RAYLIB_NUKLEAR_VERSION macros
+    Assert(RAYLIB_NUKLEAR_VERSION_MAJOR >= 1);
+    Assert(RAYLIB_NUKLEAR_VERSION_MINOR >= 0);
+    Assert(RAYLIB_NUKLEAR_VERSION_PATCH >= 0);
+    #if RAYLIB_NUKLEAR_VERSION_MAJOR >= 6
+    Assert(1);
+    #endif
+    Assert(TextIsEqual(RAYLIB_NUKLEAR_VERSION, "6.0.1"));
+
     CloseWindow();
     TraceLog(LOG_INFO, "================================");
     TraceLog(LOG_INFO, "raylib-nuklear tests succesful");

--- a/test/raylib-nuklear-test.c
+++ b/test/raylib-nuklear-test.c
@@ -206,7 +206,6 @@ int main(int argc, char *argv[]) {
     Assert(RAYLIB_NUKLEAR_VERSION_MAJOR >= 1);
     Assert(RAYLIB_NUKLEAR_VERSION_MINOR >= 0);
     Assert(RAYLIB_NUKLEAR_VERSION_PATCH >= 0);
-    Assert(TextIsEqual(RAYLIB_NUKLEAR_VERSION, "6.0.1"));
 
     CloseWindow();
     TraceLog(LOG_INFO, "================================");


### PR DESCRIPTION
Adds `RAYLIB_NUKLEAR_VERSION`, `RAYLIB_NUKLEAR_VERSION_MAJOR`, `RAYLIB_NUKLEAR_VERSION_MINOR`, and `RAYLIB_NUKLEAR_VERSION_PATCH` macros matching the raygui convention.

Fixes #111