### PR TITLE
Use GetMouseWheelMoveV() for horizontal scroll support

### DIFF
--- a/include/raylib-nuklear.h
+++ b/include/raylib-nuklear.h
@@ -982,12 +982,10 @@ nk_raylib_input_mouse(struct nk_context * ctx)
     }
 
     // Mouse Wheel
-    float mouseWheel = GetMouseWheelMove();
-    if (mouseWheel != 0.0f) {
-        struct nk_vec2 mouseWheelMove;
-        mouseWheelMove.x = 0.0f;
-        mouseWheelMove.y = mouseWheel;
-        nk_input_scroll(ctx, mouseWheelMove);
+    Vector2 mouseWheel = GetMouseWheelMoveV();
+    if (mouseWheel.x != 0.0f || mouseWheel.y != 0.0f) {
+        struct nk_vec2 scroll = {mouseWheel.x, mouseWheel.y};
+        nk_input_scroll(ctx, scroll);
     }
 }
 


### PR DESCRIPTION
Replaces `GetMouseWheelMove()` (vertical only) with `GetMouseWheelMoveV()` so horizontal scroll from touchpads and horizontal scroll wheels is passed to Nuklear.

Fixes #110