### PR TITLE
input: route single-finger touch as left-button click

### DIFF
--- a/include/raylib-nuklear.h
+++ b/include/raylib-nuklear.h
@@ -976,11 +976,20 @@ NK_API void
 nk_raylib_input_mouse(struct nk_context * ctx)
 {
     const float scale = GetNuklearScaling(ctx);
-    const int mouseX = (int)((float)GetMouseX() / scale);
-    const int mouseY = (int)((float)GetMouseY() / scale);
+    int mouseX = (int)((float)GetMouseX() / scale);
+    int mouseY = (int)((float)GetMouseY() / scale);
+    nk_bool leftDown = IsMouseButtonDown(MOUSE_LEFT_BUTTON) ? nk_true : nk_false;
+
+    // Route single-finger touch as left-button click
+    if (GetTouchCount() > 0) {
+        Vector2 touchPos = GetTouchPosition(0);
+        mouseX = (int)(touchPos.x / scale);
+        mouseY = (int)(touchPos.y / scale);
+        leftDown = nk_true;
+    }
 
     nk_input_motion(ctx, mouseX, mouseY);
-    nk_input_button(ctx, NK_BUTTON_LEFT, mouseX, mouseY, IsMouseButtonDown(MOUSE_LEFT_BUTTON));
+    nk_input_button(ctx, NK_BUTTON_LEFT, mouseX, mouseY, leftDown);
     nk_input_button(ctx, NK_BUTTON_RIGHT, mouseX, mouseY, IsMouseButtonDown(MOUSE_RIGHT_BUTTON));
     nk_input_button(ctx, NK_BUTTON_MIDDLE, mouseX, mouseY, IsMouseButtonDown(MOUSE_MIDDLE_BUTTON));
 

--- a/include/raylib-nuklear.h
+++ b/include/raylib-nuklear.h
@@ -978,8 +978,11 @@ NK_API void
 nk_raylib_input_mouse(struct nk_context * ctx)
 {
     const float scale = GetNuklearScaling(ctx);
-    int mouseX = (int)((float)GetMouseX() / scale);
-    int mouseY = (int)((float)GetMouseY() / scale);
+
+    // Determine the mouse position.
+    const Vector2 mousePosition = GetMousePosition();
+    int mouseX = (int)(mousePosition.x / scale);
+    int mouseY = (int)(mousePosition.y / scale);
     nk_bool leftDown = IsMouseButtonDown(MOUSE_LEFT_BUTTON) ? nk_true : nk_false;
 
     // Route single-finger touch as left-button click

--- a/include/raylib-nuklear.h
+++ b/include/raylib-nuklear.h
@@ -983,7 +983,7 @@ nk_raylib_input_mouse(struct nk_context * ctx)
     nk_bool leftDown = IsMouseButtonDown(MOUSE_LEFT_BUTTON) ? nk_true : nk_false;
 
     // Route single-finger touch as left-button click
-    if (GetTouchCount() > 0) {
+    if (GetTouchPointCount() > 0) {
         Vector2 touchPos = GetTouchPosition(0);
         mouseX = (int)(touchPos.x / scale);
         mouseY = (int)(touchPos.y / scale);


### PR DESCRIPTION
In `nk_raylib_input_mouse()`, when `GetTouchCount() > 0`, overrides the cursor position with `GetTouchPosition(0)` and sets left-button as pressed, enabling touch interaction on mobile and web builds without changing desktop mouse behavior. Fixes #123